### PR TITLE
Fix PRD path casing

### DIFF
--- a/README-task-master.md
+++ b/README-task-master.md
@@ -133,7 +133,7 @@ Claude Task Master is designed to work seamlessly with [Cursor AI](https://www.c
 
 1. After initializing your project, open it in Cursor
 2. The `.cursor/rules/dev_workflow.mdc` file is automatically loaded by Cursor, providing the AI with knowledge about the task management system
-3. Place your PRD document in the `scripts/` directory (e.g., `scripts/prd.txt`)
+3. Place your PRD document in the `scripts/` directory (e.g., `scripts/PRD.txt`)
 4. Open Cursor's AI chat and switch to Agent mode
 
 ### Setting up MCP in Cursor
@@ -156,13 +156,13 @@ Once configured, you can interact with Task Master's task management commands di
 In Cursor's AI chat, instruct the agent to generate tasks from your PRD:
 
 ```
-Please use the task-master parse-prd command to generate tasks from my PRD. The PRD is located at scripts/prd.txt.
+Please use the task-master parse-prd command to generate tasks from my PRD. The PRD is located at scripts/PRD.txt.
 ```
 
 The agent will execute:
 
 ```bash
-task-master parse-prd scripts/prd.txt
+task-master parse-prd scripts/PRD.txt
 ```
 
 This will:
@@ -597,7 +597,7 @@ The `show` command:
 ### Starting a new project
 
 ```
-I've just initialized a new project with Claude Task Master. I have a PRD at scripts/prd.txt.
+I've just initialized a new project with Claude Task Master. I have a PRD at scripts/PRD.txt.
 Can you help me parse it and set up the initial tasks?
 ```
 

--- a/tasks/tasks.json
+++ b/tasks/tasks.json
@@ -179,7 +179,7 @@
   "metadata": {
     "projectName": "Ansuz Implementation",
     "totalTasks": 10,
-    "sourceFile": "scripts/prd.txt",
+    "sourceFile": "scripts/PRD.txt",
     "generatedAt": "2023-11-09"
   }
 }


### PR DESCRIPTION
## Summary
- correct case of `scripts/PRD.txt` in README documentation
- fix `sourceFile` path in `tasks.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4b057c28832ebdcb7652c4626f1c