### PR TITLE
Implement CLI pipeline with stubs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,65 @@
-# main.py - Entry point for the Ansuz application
+"""Command-line interface for the Ansuz application."""
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from src.config_loader import load_config
+from src.input_handler import InputHandler
+from src.llm_processor import LLMProcessor
+from src.content_structurer import ContentStructurer
+from src.html_generator import HTMLGenerator
+
+
+def parse_args() -> ArgumentParser:
+    parser = ArgumentParser(description="Process transcripts into structured HTML")
+    parser.add_argument(
+        "--text",
+        help="Raw text input provided directly on the command line",
+    )
+    parser.add_argument(
+        "--file",
+        help="Path to a text file containing the transcript",
+    )
+    parser.add_argument(
+        "--youtube",
+        help="URL of a YouTube video to fetch the transcript from",
+    )
+    parser.add_argument(
+        "--output",
+        default="output.html",
+        help="Path to save the generated HTML (default: output.html)",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = parse_args()
+    args = parser.parse_args()
+
+    if not any([args.text, args.file, args.youtube]):
+        parser.print_help()
+        raise SystemExit("Please provide --text, --file, or --youtube")
+
+    config = load_config()
+
+    input_handler = InputHandler()
+    transcript = input_handler.get_input(
+        text=args.text, file_path=args.file, youtube_url=args.youtube
+    )
+
+    llm = LLMProcessor(config)
+    analysis = llm.analyze(transcript)
+
+    structurer = ContentStructurer()
+    structured = structurer.structure(transcript, analysis)
+
+    generator = HTMLGenerator()
+    html = generator.generate(structured)
+
+    output_path = Path(args.output)
+    output_path.write_text(html, encoding="utf-8")
+    print(f"HTML saved to {output_path}")
+
 
 if __name__ == "__main__":
-    print("Ansuz application started.")
-    # Future application logic will go here
-    pass 
+    main()

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -1,0 +1,14 @@
+import os
+from typing import Dict
+
+
+def load_config() -> Dict[str, str]:
+    """Load configuration settings from environment variables.
+
+    This simple loader checks common environment variables that might be
+    required by other modules. It can be expanded later to read from files
+    or other sources.
+    """
+    return {
+        "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY", ""),
+    }

--- a/src/content_structurer.py
+++ b/src/content_structurer.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict, List
+
+
+class ContentStructurer:
+    """Organize LLM output into a final structure."""
+
+    def structure(self, text: str, analysis: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+        """Return structured content.
+
+        The default implementation simply passes the analysis through.
+        Future versions will ensure all content is preserved and organized
+        under headings.
+        """
+        return analysis

--- a/src/html_generator.py
+++ b/src/html_generator.py
@@ -1,0 +1,16 @@
+from typing import Dict, List
+
+
+class HTMLGenerator:
+    """Generate HTML from structured content."""
+
+    def generate(self, sections: List[Dict[str, str]]) -> str:
+        html_parts = ["<html>", "<body>"]
+        for section in sections:
+            heading = section.get("heading", "")
+            content = section.get("content", "")
+            html_parts.append(f"<h2>{heading}</h2>")
+            html_parts.append(f"<p>{content}</p>")
+        html_parts.append("</body>")
+        html_parts.append("</html>")
+        return "\n".join(html_parts)

--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from typing import Optional
+
+
+class InputHandler:
+    """Handle user-provided input for transcript processing."""
+
+    def get_input(
+        self,
+        *,
+        text: Optional[str] = None,
+        file_path: Optional[str] = None,
+        youtube_url: Optional[str] = None,
+    ) -> str:
+        """Return transcript text from one of the supported sources."""
+        if text:
+            return text
+
+        if file_path:
+            path = Path(file_path)
+            if not path.is_file():
+                raise FileNotFoundError(f"File not found: {file_path}")
+            return path.read_text(encoding="utf-8")
+
+        if youtube_url:
+            # Placeholder for YouTube transcript fetching logic.
+            # Future implementations will fetch the transcript from the URL.
+            raise NotImplementedError("YouTube URL handling not implemented yet")
+
+        raise ValueError("No valid input source provided")

--- a/src/llm_processor.py
+++ b/src/llm_processor.py
@@ -1,0 +1,16 @@
+from typing import Any, Dict, List
+
+
+class LLMProcessor:
+    """Placeholder processor that would call an LLM service."""
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+
+    def analyze(self, text: str) -> List[Dict[str, str]]:
+        """Analyze the text and return structured sections.
+
+        This stub implementation simply wraps the entire text in a single
+        section. Real implementations would integrate with an LLM API.
+        """
+        return [{"heading": "Transcript", "content": text}]


### PR DESCRIPTION
## Summary
- add skeleton modules in `src/`
- implement an argparse-based CLI in `main.py`
- load configuration with `config_loader`
- run transcript through `InputHandler`, `LLMProcessor`, `ContentStructurer`, and `HTMLGenerator`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4e7c9770832e8fbb89535339d899