### PR TITLE
Implement minimal text processing pipeline

### DIFF
--- a/src/content_structurer.py
+++ b/src/content_structurer.py
@@ -12,4 +12,21 @@ class ContentStructurer:
 
     def organize_segments(self, transcript: str, analysis: dict) -> list:
         """Return a structured representation of ``transcript``."""
-        raise NotImplementedError
+        headings = analysis.get("topics", []) if analysis else []
+
+        paragraphs = [p.strip() for p in transcript.split("\n\n") if p.strip()]
+
+        if not headings:
+            return [{"heading": None, "content": paragraphs}]
+
+        structure = []
+        num_headings = len(headings)
+        for i, heading in enumerate(headings):
+            start = i * len(paragraphs) // num_headings
+            end = (i + 1) * len(paragraphs) // num_headings
+            structure.append({
+                "heading": heading,
+                "content": paragraphs[start:end],
+            })
+
+        return structure

--- a/src/html_generator.py
+++ b/src/html_generator.py
@@ -5,6 +5,7 @@ output. Future implementations will load templates and render them with
 data provided by the content structurer."""
 
 from __future__ import annotations
+from jinja2 import Template
 
 
 class HTMLGenerator:
@@ -12,4 +13,26 @@ class HTMLGenerator:
 
     def generate_html(self, structured_content) -> str:
         """Return HTML representing ``structured_content``."""
-        raise NotImplementedError
+        template_str = """
+        <html>
+        <head>
+            <meta charset='utf-8'>
+            <title>Ansuz Output</title>
+            <style>
+                body {font-family: Arial, sans-serif; margin: 2em;}
+                h2 {margin-top: 1.5em;}
+            </style>
+        </head>
+        <body>
+        {% for section in content %}
+            {% if section.heading %}<h2>{{ section.heading }}</h2>{% endif %}
+            {% for paragraph in section.content %}
+                <p>{{ paragraph }}</p>
+            {% endfor %}
+        {% endfor %}
+        </body>
+        </html>
+        """
+
+        template = Template(template_str)
+        return template.render(content=structured_content)

--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -19,11 +19,15 @@ class InputHandler:
         text: str
             Raw text supplied by the user.
         """
-        raise NotImplementedError
+        # Strip leading/trailing whitespace and collapse internal
+        # whitespace to single spaces for a basic normalization.
+        cleaned = " ".join(text.split())
+        return cleaned
 
     def read_file(self, file_path: str) -> str:
         """Read text from ``file_path`` and return its contents."""
-        raise NotImplementedError
+        with open(file_path, "r", encoding="utf-8") as fh:
+            return fh.read()
 
     def validate_input(self, text: str) -> bool:
         """Validate provided text input.
@@ -31,4 +35,4 @@ class InputHandler:
         This check will ensure the text is not empty and meets any
         additional criteria defined in future development.
         """
-        raise NotImplementedError
+        return bool(text and text.strip())

--- a/src/llm_processor.py
+++ b/src/llm_processor.py
@@ -12,4 +12,13 @@ class LLMProcessor:
 
     def call_api(self, prompt: str) -> str:
         """Send ``prompt`` to the LLM and return its response."""
-        raise NotImplementedError
+        # This is a lightweight stub used for development and testing
+        # without making actual API requests.
+        _ = prompt  # acknowledge the prompt without using it
+        return {
+            "topics": [
+                "Introduction",
+                "Main Discussion",
+                "Conclusion",
+            ]
+        }


### PR DESCRIPTION
## Summary
- add basic text cleaning, file reading, and validation
- mock LLM API with static topics
- organize transcript segments into topic groups
- generate simple HTML output using Jinja2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f51ef5a94832ebd2ee50723e7a2c6