### PR TITLE
Add basic CLI and tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,42 @@
 
 from __future__ import annotations
 
+import argparse
+from pathlib import Path
 
-def main() -> None:
+from src.config_loader import load_config
+from src.input_handler import InputHandler
+
+
+def main(argv: list[str] | None = None) -> None:
     """Run the application."""
-    print("Ansuz application started.")
-    # Future application logic will go here
+    parser = argparse.ArgumentParser(description="Ansuz processing pipeline")
+    parser.add_argument("--input", help="Path to input text file")
+    parser.add_argument("--text", help="Raw text to process")
+    parser.add_argument("--output", required=True, help="Output file path")
+    parser.add_argument(
+        "--env-file", default=".env", help="Environment file for configuration"
+    )
+
+    args = parser.parse_args(argv)
+
+    load_config(args.env_file)
+    handler = InputHandler()
+
+    text = ""
+    if args.input:
+        text = handler.read_file(args.input)
+    elif args.text:
+        text = args.text
+
+    if not handler.validate_input(text):
+        parser.error("No valid input provided")
+
+    processed = handler.process_text(text)
+
+    out_path = Path(args.output)
+    out_path.write_text(processed, encoding="utf-8")
+    print(f"Output written to {out_path}")
 
 
 if __name__ == "__main__":

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -1,5 +1,17 @@
-from dotenv import load_dotenv
 import os
+
+try:
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # pragma: no cover - fallback when package missing
+    def load_dotenv(path: str = ".env") -> None:
+        """Simple dotenv loader used when python-dotenv is unavailable."""
+        if not os.path.exists(path):
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                if "=" in line:
+                    key, value = line.strip().split("=", 1)
+                    os.environ.setdefault(key, value)
 
 
 def load_config(env_file: str = ".env") -> dict:

--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -19,11 +19,12 @@ class InputHandler:
         text: str
             Raw text supplied by the user.
         """
-        raise NotImplementedError
+        return text.strip()
 
     def read_file(self, file_path: str) -> str:
         """Read text from ``file_path`` and return its contents."""
-        raise NotImplementedError
+        with open(file_path, "r", encoding="utf-8") as f:
+            return f.read()
 
     def validate_input(self, text: str) -> bool:
         """Validate provided text input.
@@ -31,4 +32,4 @@ class InputHandler:
         This check will ensure the text is not empty and meets any
         additional criteria defined in future development.
         """
-        raise NotImplementedError
+        return bool(text and text.strip())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from src.input_handler import InputHandler
+
+CLI_PYTHON = sys.executable
+
+
+def test_cli_creates_output(tmp_path):
+    output = tmp_path / "out.txt"
+    result = subprocess.run([
+        CLI_PYTHON,
+        "-m",
+        "main",
+        "--text",
+        "sample",
+        "--output",
+        str(output),
+    ], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert output.read_text() == "sample"
+

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,14 @@
+import os
+from src.config_loader import load_config
+
+def test_load_config_defaults_and_env(tmp_path, monkeypatch):
+    env_file = tmp_path / "test.env"
+    env_file.write_text("MODEL=custom\nTEMPERATURE=0.5\n")
+    monkeypatch.setenv("LOG_LEVEL", "debug")
+    monkeypatch.delenv("PERPLEXITY_MODEL", raising=False)
+    config = load_config(str(env_file))
+    assert config["MODEL"] == "custom"
+    assert config["TEMPERATURE"] == 0.5
+    assert config["LOG_LEVEL"] == "debug"
+    assert config["PERPLEXITY_MODEL"] == "sonar-pro"
+

--- a/tests/test_input_handler.py
+++ b/tests/test_input_handler.py
@@ -1,0 +1,13 @@
+from src.input_handler import InputHandler
+
+def test_read_file(tmp_path):
+    file_path = tmp_path / "input.txt"
+    file_path.write_text("data")
+    handler = InputHandler()
+    assert handler.read_file(str(file_path)) == "data"
+
+def test_validate_input():
+    handler = InputHandler()
+    assert handler.validate_input("hello")
+    assert not handler.validate_input("   ")
+


### PR DESCRIPTION
## Summary
- implement InputHandler file reading and validation
- add fallback dotenv implementation
- create a simple CLI in `main.py`
- add tests for configuration loader, input handler, and CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f51f0021c832e942d783dd71719ba